### PR TITLE
add async_status to PS module doc blacklist

### DIFF
--- a/ansible_testing/modules.py
+++ b/ansible_testing/modules.py
@@ -129,6 +129,7 @@ class ModuleValidator(Validator):
     BLACKLIST = BLACKLIST_FILES.union(BLACKLIST_MODULES)
 
     PS_DOC_BLACKLIST = frozenset((
+        'async_status.ps1',
         'slurp.ps1',
         'setup.ps1'
     ))


### PR DESCRIPTION
prevent errors for new PS module not co-located with docs
