### PR TITLE
short_description is just basestring

### DIFF
--- a/ansible_testing/schema.py
+++ b/ansible_testing/schema.py
@@ -32,7 +32,7 @@ option_schema = Schema(
 doc_schema = Schema(
     {
         Required('module'): basestring,
-        'short_description': Any(basestring, [basestring]),
+        'short_description': basestring,
         'description': Any(basestring, [basestring]),
         'version_added': Any(basestring, float),
         'author': Any(None, basestring, [basestring]),


### PR DESCRIPTION
As of ansible/ansible 883f4511580761c01d3b39b20b6fb4739c94a7fa
'short_description' value is expected to only be a string.

This should catch issues like
https://github.com/ansible/ansible/issues/17634
